### PR TITLE
Using gulp to set the value of Rt106_SERVER_URL from environment vari…

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
     "csvtojson": "^1.1.4",
     "date-format": "0.0.2",
     "express": "^4.13.4",
+    "gulp": "^3.9.1",
+    "gulp-ng-constant": "^1.2.0",
     "mysql": "~2.11.1",
     "request": "^2.81.0",
     "request-promise": "^3.0.0",

--- a/public/config.js
+++ b/public/config.js
@@ -1,9 +1,7 @@
-// Copyright (c) General Electric Company, 2017.  All rights reserved.
+angular.module("rt106.config", [])
 
-angular.module('rt106.config', [])
+.constant("API_VERSION", "v1")
 
-  .constant('API_VERSION', 'v1')
-
-  .constant('Rt106_SERVER_URL', 'http://localhost')
+.constant("Rt106_SERVER_URL", "http://localhost")
 
 ;

--- a/public/config.json
+++ b/public/config.json
@@ -1,0 +1,5 @@
+{
+  "API_VERSION": "v1",
+  "Rt106_SERVER_URL": "http://localhost"
+}
+

--- a/rt106-app/config.js
+++ b/rt106-app/config.js
@@ -1,9 +1,7 @@
-// Copyright (c) General Electric Company, 2017.  All rights reserved.
+angular.module("rt106.config", [])
 
-angular.module('rt106.config', [])
+    .constant("API_VERSION", "v1")
 
-  .constant('API_VERSION', 'v1')
-
-  .constant('Rt106_SERVER_URL', 'http://localhost')
+    .constant("Rt106_SERVER_URL", "http://localhost")
 
 ;

--- a/rt106-app/config.json
+++ b/rt106-app/config.json
@@ -1,0 +1,4 @@
+{
+  "API_VERSION": "v1",
+  "Rt106_SERVER_URL": "http://localhost"
+}

--- a/rt106-server/rt106-server.js
+++ b/rt106-server/rt106-server.js
@@ -10,7 +10,6 @@ const request      = require('request');
 const csv          = require('csvtojson');
 //const cors         = require('cors');
 
-
 const winston      = require('winston');
 
 // Rt 106 modules
@@ -20,6 +19,38 @@ const healthMgr    = require('./healthMgr');  // module for checking the health 
 
 var AMQPmgr      = null; // optional module for managing RabbitMQ queues.
 var SQSmgr       = null; // optional module for managing SQS queues
+
+/*
+ * Dynamically create the config.js file.
+ * If the environment variable Rt106_SERVER_HOST is defined, that is used in config.js.  Otherwise localhost is used.
+ * If the environment variable Rt106_APP_DIR is defined, that is the location where config.js needs to be.  Otherwise use rt106-app.
+ */
+var gulp = require('gulp');
+var ngConstant = require('gulp-ng-constant');
+var Rt106_SERVER_URL = 'http://localhost'; // Default value, may be changed below.
+if (process.env.Rt106_SERVER_HOST !== undefined) {
+    Rt106_SERVER_URL = 'http://' + process.env.Rt106_SERVER_HOST;
+}
+console.log("gulp setting Rt106_SERVER_URL to " + Rt106_SERVER_URL);
+var Rt106_APP_DIR = 'rt106-app';
+if (process.env.Rt106_SERVE_APP !== undefined) {
+    Rt106_APP_DIR = process.env.Rt106_SERVE_APP;
+}
+gulp.task('default', function() {
+    gulp.src(Rt106_APP_DIR + '/config.json')
+        .pipe(ngConstant({
+            name: 'rt106.config',
+            constants:
+                {
+                    Rt106_SERVER_URL: Rt106_SERVER_URL
+                }
+        }))
+        .pipe(gulp.dest(Rt106_APP_DIR));
+});
+gulp.start('default');
+/*
+ * End of dynamic creation of config.js.
+ */
 
 // Constants
 const PORT = 8106;


### PR DESCRIPTION
…able Rt106_SERVER_HOST.  This eliminates the need to rebuild the Docker image to run on a different machine and not have the browser on localhost.